### PR TITLE
Fix scan accept/reject gating and pose bookkeeping; expose plane rejection stats

### DIFF
--- a/super_odometry/src/LidarProcess/LidarSlam.cpp
+++ b/super_odometry/src/LidarProcess/LidarSlam.cpp
@@ -53,7 +53,11 @@ namespace super_odometry {
     void LidarSLAM::initializeState(bool initialization, const Transformd&position){
         T_w_lidar=position;
         T_w_initial_guess=position;
-        last_T_w_lidar=T_w_lidar;
+        // Keep `last_T_w_lidar` as the previous *accepted* pose for motion checks/statistics.
+        // Only initialize it on the very first frame.
+        if (!initialization) {
+            last_T_w_lidar = T_w_lidar;
+        }
     }
     
 
@@ -160,11 +164,15 @@ namespace super_odometry {
         updateOptimizationStats(t_opt, stats);
         
         // Check motion thresholds and update map
-        if (checkMotionThresholds(timeLaserOdometry, stats)) {
+        const bool accept = checkMotionThresholds(timeLaserOdometry, stats);
+        if (accept) {
             // Transform and add new features to map
             transformAndAddToMap(EdgesPoints, WorldEdgesPoints, true);
             transformAndAddToMap(PlanarsPoints, WorldPlanarsPoints, false);
         }
+
+        // Update last pose for next frame (if scan was rejected, T_w_lidar has been reverted already)
+        last_T_w_lidar = T_w_lidar;
         
         // Update timing
         lasttimeLaserOdometry = timeLaserOdometry;
@@ -174,13 +182,21 @@ namespace super_odometry {
     
         bool acceptResult = true;
         double delta_t = timeLaserOdometry - lasttimeLaserOdometry;
+
+        // Guard against invalid timestamps; if we can't estimate velocity robustly, accept the update.
+        if (delta_t <= 1e-6) {
+            return true;
+        }
         
         // Check velocity threshold
-        if (stats.translation_from_last/delta_t > OptSet.velocity_failure_threshold) {
+        const double velocity = stats.translation_from_last / delta_t;
+        if (velocity > OptSet.velocity_failure_threshold) {
             T_w_lidar = last_T_w_lidar;
             startupCount = 5;
             acceptResult = false;
-            RCLCPP_WARN(node_->get_logger(), "large motion detected, ignoring predictor for a while");
+            RCLCPP_WARN(node_->get_logger(),
+                        "Large motion detected (|dp|=%.3f m, dt=%.3f s, v=%.3f m/s > %.3f). Rejecting scan.",
+                        stats.translation_from_last, delta_t, velocity, OptSet.velocity_failure_threshold);
         }
         
         // Check small motion threshold
@@ -190,8 +206,7 @@ namespace super_odometry {
             RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000,
                                 "very small motion, not accumulating. %f", stats.translation_from_last);
         }
-    acceptResult = true;
-    return acceptResult;
+        return acceptResult;
 }
 
 
@@ -206,7 +221,15 @@ namespace super_odometry {
 
         stats.translation_from_last = diff_from_last_T.pos.norm();
         stats.rotation_from_last = 2 * atan2(diff_from_last_T.rot.vec().norm(), diff_from_last_T.rot.w());
-        last_T_w_lidar=T_w_lidar;
+
+        // Plane correspondence / rejection breakdown (from the last ICP iteration).
+        stats.plane_match_success = MatchRejectionHistogramPlane[MatchingResult::SUCCESS].load();
+        stats.plane_no_enough_neighbor = MatchRejectionHistogramPlane[MatchingResult::NOT_ENOUGH_NEIGHBORS].load();
+        stats.plane_neighbor_too_far = MatchRejectionHistogramPlane[MatchingResult::NEIGHBORS_TOO_FAR].load();
+        stats.plane_badpca_structure = MatchRejectionHistogramPlane[MatchingResult::BAD_PCA_STRUCTURE].load();
+        stats.plane_invalid_numerical = MatchRejectionHistogramPlane[MatchingResult::INVAVLID_NUMERICAL].load();
+        stats.plane_mse_too_large = MatchRejectionHistogramPlane[MatchingResult::MSE_TOO_LARGE].load();
+        stats.plane_unknown = MatchRejectionHistogramPlane[MatchingResult::UNKNON].load();
     }
 
 

--- a/super_odometry/src/parameter/parameter.cpp
+++ b/super_odometry/src/parameter/parameter.cpp
@@ -295,7 +295,7 @@ bool readGlobalparam(rclcpp::Node::SharedPtr node)
     node->declare_parameter<double>("imu_acc_x_limit", 0.5);
     node->declare_parameter<double>("imu_acc_y_limit", 0.2);
     node->declare_parameter<double>("imu_acc_z_limit", 0.4);
-    // node->declare_parameter<bool>("use_imu_roll_pitch", false);
+    node->declare_parameter<bool>("use_imu_roll_pitch", false);
 
     
     LASER_TOPIC = node->get_parameter("laser_topic").as_string();
@@ -309,7 +309,7 @@ bool readGlobalparam(rclcpp::Node::SharedPtr node)
     SENSOR_FRAME_ROT = node->get_parameter("sensor_frame_rot").as_string();
     ProjectName = node->get_parameter("PROJECT_NAME").as_string();
     SENSOR = node->get_parameter("sensor").as_string();
-    // USE_IMU_ROLL_PITCH = node->get_parameter("use_imu_roll_pitch").as_bool();
+    USE_IMU_ROLL_PITCH = node->get_parameter("use_imu_roll_pitch").as_bool();
     IMU_ACC_X_LIMIT = node->get_parameter("imu_acc_x_limit").as_double();
     IMU_ACC_Y_LIMIT = node->get_parameter("imu_acc_y_limit").as_double();
     IMU_ACC_Z_LIMIT = node->get_parameter("imu_acc_z_limit").as_double();
@@ -336,6 +336,7 @@ bool readGlobalparam(rclcpp::Node::SharedPtr node)
     RCLCPP_INFO(node->get_logger(), "SENSOR_FRAME_ROT %s", SENSOR_FRAME_ROT.c_str());
     RCLCPP_INFO(node->get_logger(), "ProjectName %s", ProjectName.c_str());
     RCLCPP_INFO(node->get_logger(), "SENSOR %s", SENSOR.c_str());
+    RCLCPP_INFO(node->get_logger(), "USE_IMU_ROLL_PITCH %s", USE_IMU_ROLL_PITCH ? "true" : "false");
 
     return true;
 }


### PR DESCRIPTION
This PR fixes a logic bug in LidarSlam.cpp that effectively disabled scan rejection, corrects
  last_T_w_lidar bookkeeping so motion deltas are computed against the last accepted pose, and makes
  plane rejection diagnostics visible in /super_odometry_stats. It also wires the global
  use_imu_roll_pitch parameter so YAML settings are actually respected.

  Changes

  1. super_odometry/src/LidarProcess/LidarSlam.cpp
      - checkMotionThresholds() now returns the real acceptResult (no forced accept) and guards
        invalid dt.
      - last_T_w_lidar is initialized only on the first frame and updated after accept/reject.
      - Plane rejection breakdown fields (plane_*) are populated from MatchRejectionHistogramPlane.
  2. super_odometry/src/parameter/parameter.cpp
      - use_imu_roll_pitch is declared and loaded into global USE_IMU_ROLL_PITCH, with logging.

  Why

  - Previously, scan rejection never took effect because the code forced acceptance at the end.
  - last_T_w_lidar was overwritten every frame, making motion statistics and gating inconsistent.
  - Plane correspondence health metrics were always zero, blocking diagnostics.

  Validation

  - Re-ran humanoid benchmarks (aligned). Metrics such as n_iterations, latency, and translation
    increments remained stable, while plane_* diagnostics are now non-zero and informative.
  - No regression observed in map visualization on the test bag (expected if rejection thresholds
    rarely trigger).
