### PR TITLE
docs: fix glog package name typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ make -j6 && sudo make install
 #### Install Ceres
 ```bash
 sudo apt update 
-sudo apt install libgoogle-glob-dev
+sudo apt install libgoogle-glog-dev
 git clone https://github.com/ceres-solver/ceres-solver.git
 cd ceres-solver
 git checkout f68321e7de8929fbcdb95dd42877531e64f72f66


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Fix the Ceres dependency package typo reported in #67: `libgoogle-glob-dev` -> `libgoogle-glog-dev`.

Fixes #67

## Test plan
- Static validation: verified `libgoogle-glob-dev` appeared exactly once in `readme.md` before replacement.
- Static validation: verified `libgoogle-glob-dev` no longer appears after the patch and `libgoogle-glog-dev` is present.
- Not run: runtime test suite, because this is a documentation-only typo fix.
